### PR TITLE
WIP: Use the tokeniser

### DIFF
--- a/client.js
+++ b/client.js
@@ -125,13 +125,11 @@ if (cluster.isMaster && MP == 'true') {
 
         i = b2048decode(i.trim());
 
-        i = i.replace(/[\n]/g,'\r');
         i = i.replace(/[“]/g,'"');
         i = i.replace(/[”]/g,'"');
         i = i.replace(/&amp;/g,'&');
         i = i.replace(/&lt;/g,'<');
         i = i.replace(/&gt;/g,'>');
-        if (!i.includes("RUN\r")) {i=i+"\rRUN\r";}
         return i;
       }
 

--- a/emulator.js
+++ b/emulator.js
@@ -53,7 +53,7 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
           for (var i = 0; i < tokenised.length; ++i) {
             processor.writemem(page + i, tokenised.charCodeAt(i));
           }
-          // Set VARTOP (0x12/3) and TOP(0x02/3)
+          // Set VARTOP (0x02/3) and TOP(0x12/3)
           var end = page + tokenised.length;
           var endLow = end & 0xff;
           var endHigh = (end >>> 8) & 0xff;

--- a/emulator.js
+++ b/emulator.js
@@ -43,12 +43,13 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
         // Set up our BBC Micro emulator
         processor = new Cpu6502(model, dbgr, video, soundChip, new DdNoise.FakeDdNoise(), new Cmos());
         await processor.initialise();
-    
-        /* Tokenizer input method
-        var t         = await tokeniser.create();
-        var tokenised = await t.tokenise(input);
-
         await runUntilInput();
+
+        if (!input.includes("\nRUN\n")) {
+          /* Tokenizer input method */
+          var t         = await tokeniser.create();
+          var tokenised = await t.tokenise(input);
+
           var page = processor.readmem(0x18) << 8;
           for (var i = 0; i < tokenised.length; ++i) {
             processor.writemem(page + i, tokenised.charCodeAt(i));
@@ -57,15 +58,20 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
           var end = page + tokenised.length;
           var endLow = end & 0xff;
           var endHigh = (end >>> 8) & 0xff;
+          // FIXME: Set LOMEM too?
+          //processor.writemem(0x00, endLow);
+          //processor.writemem(0x01, endHigh);
           processor.writemem(0x02, endLow);
           processor.writemem(0x03, endHigh);
           processor.writemem(0x12, endLow);
           processor.writemem(0x13, endHigh);
 
-        input="RUN\r";
-        */
-    
-        await runUntilInput();
+          input="RUN\r";
+        } else {
+          // FIXME: This fallback doesn't seem to actually work properly...
+          input=input.replace(/[\n]/g,'\r');
+        }
+
         await pasteToBuffer(input);
         await runFor((2000000*duration)-15000*(input.length));
 

--- a/test.js
+++ b/test.js
@@ -17,9 +17,9 @@ function Tests(since_id){
     },
     {
       name: "CHARACTERS",
-      text: "10 PRINT\“&gt;&amp;&lt;\”\n20 VDU 23,1,0;0;0;0;\n", // Tests twitter HTML escapes for <,&,> and OS X auto ""
+      text: "0 CLS\n10 PRINT\“&gt;&amp;&lt;\”\n20 VDU 23,1,0;0;0;0;\n", // Tests twitter HTML escapes for <,&,> and OS X auto ""
       mediaType: "image/png",
-      checksum: "98da55d5a8f7db98e4ebd3c156eb971ca4608ee7"
+      checksum: "aedb0240c4152ad77500a4fffd6f36c7edab4ce5"
     },
     {
       name: "BASE2048", // Test code HT @kweepa


### PR DESCRIPTION
I thought I'd see what needed fixing for the commented out tokeniser code to work - not much it seems!  The testcase tweak is just because the old approach means the program getting typed in appears in the output, whereas it doesn't with the tokeniser - I added `CLS` so both approaches give the same output.

However, this is not 100% compatible with all existing tweets, and I'm not sure what we can do about that.  Perhaps we at least should have a way to run them by faking keypresses via a configuration option?  It'd be good to have a clear strategy for compatibility as it's something that's likely to come up repeatedly now people can send patches.

Currently this patch attempts to handle tweets containing an explicit `RUN` the old way, but that doesn't actually work properly - I haven't debugged why enough to work out the issue.  I'm also not sure if we actually want to do this, but it at least illustrates that we can probably keep both code paths in place cleanly.

I wonder if we should also set `LOMEM`?  It's reset by `RUN`, but then so is `VARTOP` and we carefully set that...

Also, this will need rebasing once #6 is merged.