### PR TITLE
Crop each video frame as we save it

### DIFF
--- a/client.js
+++ b/client.js
@@ -164,7 +164,7 @@ if (cluster.isMaster && MP == 'true') {
           // STATIC IMAGE WITHOUT SOUND -> PNG SCREENSHOT
           var mediaFilename = path+'.png';
           var mediaType = 'image/png';
-          var ffmpegCmd = 'ffmpeg -hide_banner -y -f rawvideo -pixel_format rgba -video_size 1024x625  -i '+path+'frame'+(frames-1)+'.rgba -vf "crop=640:512:200:64,scale=1280:1024" '+mediaFilename
+          var ffmpegCmd = 'ffmpeg -hide_banner -y -f rawvideo -pixel_format rgba -video_size 640x512  -i '+path+'frame'+(frames-1)+'.rgba -vf "scale=1280:1024" '+mediaFilename
         } else {
           // ANIMATION OR STATIC IMAGE WITH SOUND -> MP4 VIDEO
           var mediaFilename = path+'.mp4';
@@ -173,7 +173,7 @@ if (cluster.isMaster && MP == 'true') {
           if (hasAudio) {
             ffmpegCmd = ffmpegCmd + '-f f32le -ar 44100 -ac 1 -i '+path+'audiotrack.raw ';
           }
-          ffmpegCmd = ffmpegCmd + '-y -f image2 -r 50 -s 1024x625 -pix_fmt rgba -vcodec rawvideo -i '+path+'frame%d.rgba  -af "highpass=f=50, lowpass=f=15000,volume=0.5" -filter:v "crop=640:512:200:64,scale=1280:1024" -q 0 -b:v 8M -b:a 128k -c:v libx264 -pix_fmt yuv420p -strict -2 -shortest '+mediaFilename
+          ffmpegCmd = ffmpegCmd + '-y -f image2 -r 50 -s 640x512 -pix_fmt rgba -vcodec rawvideo -i '+path+'frame%d.rgba  -af "highpass=f=50, lowpass=f=15000,volume=0.5" -filter:v "scale=1280:1024" -q 0 -b:v 8M -b:a 128k -c:v libx264 -pix_fmt yuv420p -strict -2 -shortest '+mediaFilename
         }
 
         await exec(ffmpegCmd);

--- a/test.js
+++ b/test.js
@@ -13,33 +13,33 @@ function Tests(since_id){
             "60 MOVE 0,0\n70 DRAW 1279,0\n80 DRAW 1279,1023\n90 DRAW 0,1023\n100 DRAW 0,0\n"+
             "110 DRAW 1279,1023\n120 VDU 23,1,0;0;0;0;\n130 P.TAB(0,16);INT(TIME/10)/10;\" s   \"\n140 GOTO 130",
       mediaType: "video/mp4",
-      checksum: "054f4e9024bc9f6f33886b68a591f94195b550de"
+      checksum: "16fcadcb6bb3b10db6f196683b6ed9129187d692"
     },
     {
       name: "CHARACTERS",
-      text: "10 PRINT“&gt;&amp;&lt;&amp;lt;”\n20 VDU 23,1,0;0;0;0;\n", // Tests twitter HTML escapes for <,&,> and OS X auto ""
+      text: "10 PRINT“&gt;&amp;&lt;&amp;lt;”'SPC39\"|\"\n20 VDU 23,1,0;0;0;0;\n", // Tests twitter HTML escapes for <,&,> and OS X auto ""
       mediaType: "image/png",
-      checksum: "75eda4b511c0f56907630fceb8d66a1b6fe00130"
+      checksum: "8054997db79c6860f43c81a73a291a3ddd59850f"
     },
     {
       name: "BASE2048", // Test code HT @kweepa
       text: '🗜Еۇಲڕਯॾ൷ԘϽѤटҪߧϙߟڒԡQԈࢤOʮߟญԁǤथطऽঋՒฤѮफՋࡢࠉƻਏಘДߡ೧շमৰٹԖϼՕՑصړͲథłҷߣƋԬնɚతࠒеदƗڵͶɢଙಇХਙࢻڕݠॶঔಘЭబƓٱUȤ೦ÐҿறԳࢤసɊঔઅЦŧԱٱߜɢडjҏƿƻঢշਢϮοեԘबঢеઉƿԛԂԜझॻȻΧҮԗՃȝ४ࢦɆςJદӘʪശऍݡબϯಜՋଦചॺږʟϮĦխҶէঐȼΧnԙҰȠछਢΑਐػϗזƄɒࠀնઉʢτԪƆമࠀནʟɄฮҸ෬խஙǷm೧౼Պ๑ɂ৮бʦடಣӷദഌࢷฐʃɟಞҏࢧȸॹ੩ɒೡΝӺݏࢪࢷฐʃЛઘԻТथطਬওՒ๑ѮࢡԪߩตʃסಅХਗഴןࠁνଛΡϗࢠसصశʃסಈϦथҺڶӊਦɣಛѮണאֆȷʏCઐײڿࢼ',
       mediaType: "image/png",
-      checksum: "80f830477fc1632c3f8a65702825f33b3d6c069e"
+      checksum: "50d22d7e91cfd11635a193fe41922617de3b7eaa"
     },
     {
       name: "STATICAUDIO", // Test static image with audio gives a video
       text: '0V.279;0;0;0;0;12:P."BEEP":REP.V.7:U.NOTINKEY50',
       mediaType: "video/mp4",
       hasAudio: true,
-      checksum: "4fa24019565b3e162cd4d1da8922334fbf3fde58"
+      checksum: "c28811f08350a0fd116ff103671e05de6f6731a5"
     },
     {
       name: "AUDIOVISUAL", // Video with sound
       text: '1MO.2:V.5:ENV.1,1,-26,-36,-45,255,255,255,127,0,0,0,126,0:SO.1,1,1,1\n2GC.0,RND(7):PL.85,RND(1280),1023A.RND:G.2\n',
       mediaType: "video/mp4",
       hasAudio: true,
-      checksum: "a6a6b7c26a94cbc3a0dd3ed253e1dd52cbc6765f"
+      checksum: "ddc2194259220d5b629f993d7988e2e01f470b01"
     },
       {name: null, text: null}
   ]


### PR DESCRIPTION
By doing this, we can adjust the crop area to fix the one column
offset to the left it previously had in MODE7.  This is due to
features of the real hardware which jsbeeb emulates (see
https://github.com/mattgodbolt/jsbeeb/issues/301).

This also nearly halves the temporary disk space needed to save
the video frames and speeds up the bot by a few percent.

This changes all the checksums in the testcases because they're
now calculated from the cropped final frame instead of the full final
frame.  I've verified by comparing output before and after (for the
non-MODE7 testcases, the output media is bit-for-bit identical).