### PR TITLE
Improve handling when no frames are captured

### DIFF
--- a/client.js
+++ b/client.js
@@ -176,8 +176,12 @@ if (cluster.isMaster && MP == 'true') {
           ffmpegCmd = ffmpegCmd + '-y -f image2 -r 50 -s 640x512 -pix_fmt rgba -vcodec rawvideo -i '+path+'frame%d.rgba  -af "highpass=f=50, lowpass=f=15000,volume=0.5" -filter:v "scale=1280:1024" -q 0 -b:v 8M -b:a 128k -c:v libx264 -pix_fmt yuv420p -strict -2 -shortest '+mediaFilename
         }
 
-        await exec(ffmpegCmd);
-        var checksum = await exec('shasum '+path+'frame'+(frames-1)+'.rgba'+" | awk '{print $1}'");
+        if (frames > 0) {
+          await exec(ffmpegCmd);
+          var checksum = await exec('shasum '+path+'frame'+(frames-1)+'.rgba'+" | awk '{print $1}'");
+        } else {
+          var checksum = '';
+        }
         exec('rm -f '+path+'*.rgba '+path+'*.raw');
 
         var end = new Date() - start

--- a/client.js
+++ b/client.js
@@ -159,7 +159,6 @@ if (cluster.isMaster && MP == 'true') {
         if (frames == 0) {
           // NO VIDEO -> NOTHING
           var ffmpegCmd = "";
-          console.warn("NO VIDEO CAPTURED");
         } else if (uniqueFrames==1 && !hasAudio) {
           // STATIC IMAGE WITHOUT SOUND -> PNG SCREENSHOT
           var mediaFilename = path+'.png';

--- a/emulator.js
+++ b/emulator.js
@@ -98,7 +98,7 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
           });
         }
 
-        return frame-capture_start;
+        return frame < capture_start ? 0 : frame-capture_start;
       }
 
 

--- a/test.js
+++ b/test.js
@@ -43,7 +43,7 @@ function Tests(since_id){
     },
     {
       name: "NOVSYNC", // Test handling of no frames captured
-      text: '1MO.2:!-512=&B0308:REP.P."HELLO WORLD":U.0',
+      text: '1MO.2:!-512=&B0308:REP.P."FAILURE IS ALWAYS AN OPTION":U.0',
       mediaType: "text/plain",
       hasAudio: false,
       checksum: ""

--- a/test.js
+++ b/test.js
@@ -41,6 +41,13 @@ function Tests(since_id){
       hasAudio: true,
       checksum: "ddc2194259220d5b629f993d7988e2e01f470b01"
     },
+    {
+      name: "NOVSYNC", // Test handling of no frames captured
+      text: '1MO.2:!-512=&B0308:REP.P."HELLO WORLD":U.0',
+      mediaType: "text/plain",
+      hasAudio: false,
+      checksum: ""
+    },
       {name: null, text: null}
   ]
 }
@@ -109,7 +116,12 @@ function Tests(since_id){
   }
 
   function noOutput(tweet) {
-    throw new Error(tweet.id_str+' TEST - \u001b[31mFAILED\u001b[0m')
+    // If the checksum is empty then we expect no output.
+    if (tweet.bbcmicrobot_checksum == '') {
+      console.log(tweet.id_str+' TEST - \u001b[32mOK\u001b[0m')
+    } else {
+      throw new Error(tweet.id_str+' TEST - \u001b[31mFAILED\u001b[0m')
+    }
   }
 
   function block(tweet) {

--- a/tweet.js
+++ b/tweet.js
@@ -57,6 +57,7 @@
 }
 
 function noOutput(tweet) {
+  console.warn("NO VIDEO CAPTURED");
   try {
     post('statuses/update', {status: "@"+tweet.user.screen_name+" Sorry, no output captured from that program", in_reply_to_status_id: tweet.id_str});
   }


### PR DESCRIPTION
If the program stops vsync happening we won't capture any frames.
In this case we now report zero frames (instead of a negative
number) and don't try to run an empty command.