### PR TITLE
Adjust isBASIC() check

### DIFF
--- a/mentions.js
+++ b/mentions.js
@@ -146,7 +146,8 @@ async function extendTruncated(timeline){
 	function isBASIC(bas){ // TODO convert to regex
 		bas = bas.replace(/@\w+/g, "").trim(); // get rid of tags and white space
 		var basic = (bas.match(/^\d/) != null) || // code must start with digit
-		bas.includes("=") || (bas.match("\uD83D\uDDDC")!=null); // Clamp emoji for compressed
+		bas.includes("=") ||
+		(bas.match("[^\0-\x7e]")!=null); // Tokens and/or clamp emoji for compressed
 		return basic;
 	}
 


### PR DESCRIPTION
Treat any tweet with non-ASCII as BASIC now that we support fully
tokenised tweets.

Suggested by @8bitkick in PR#21.