### PR TITLE
Handle exception from tokeniser

### DIFF
--- a/emulator.js
+++ b/emulator.js
@@ -90,7 +90,15 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
         if (/[^\0-\x7e]/.test(input) || !/^ *[0-9]/m.test(input)) {
           /* Tokeniser input method */
           var t         = await tokeniser.create();
-          var tokenised = await t.tokenise(input);
+          var tokenised;
+          try {
+            tokenised = await t.tokenise(input);
+          }
+          catch (e) {
+            console.log("Tokenisation FAILED");
+            console.log(e);
+            return 0;
+          }
 
           var page = processor.readmem(0x18) << 8;
           for (var i = 0; i < tokenised.length; ++i) {

--- a/test.js
+++ b/test.js
@@ -88,6 +88,12 @@ function Tests(since_id){
       mediaType: "image/png",
       checksum: "ff26b135a00313cfce0ee0a6fcc995cc80426589"
     },
+    {
+      name: "OVERLONG", // Test overlong line doesn't crash the bot
+      text: "REM " + ("BBC".repeat(88)),
+      mediaType: "text/plain",
+      checksum: ""
+    },
       {name: null, text: null}
   ]
 }


### PR DESCRIPTION
The tokeniser will throw an exception if an input line is too long
after tokenising - we need to handle this so the client process
doesn't exit.

Closes #27