### PR TITLE
Tokenise for beebjit

### DIFF
--- a/client.js
+++ b/client.js
@@ -85,10 +85,18 @@ var clientID = "Cli0";
           var emu_name = "beebjit";
 
           // Run tweet on emulator
-          await fs.writeFileSync("./beebasm/text.bas",c.input+"\rRUN\r");
-          await exec("cd beebasm && ./beebasm -i makedisk.asm -do tweet.ssd -opt 3");
+          var tokenised;
+          try {
+            tokenised = await emulator.tokenise(c.input);
+          } catch (e) {
+            console.log("Tokenisation FAILED");
+            console.log(e);
+            return 0;
+          }
+          await fs.writeFileSync("./beebasm/tokenised.bas",tokenised,{encoding:"binary"});
+          await fs.writeFileSync("./beebasm/run.txt","LO.\"TWEET\"\nP.CHR$11CHR$11SPC80CHR$11CHR$11;\nRUN\n");
+          await exec("cd beebasm && ./beebasm -i makedisk2.asm -do tweet.ssd -opt 3");
           await exec("cd beebjit && ./beebjit -0 ../beebasm/tweet.ssd -fast -headless -autoboot -opt video:border-chars=0 "+c.flags);
-
         } else // JSbeeb
         {
           var path = output;

--- a/emulator.js
+++ b/emulator.js
@@ -20,6 +20,12 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
 
   var screenMode = 0x0355; // Current screen mode.
 
+  async function tokenise(input) {
+    return await tokeniser.create().then(function (t) {
+      return t.tokenise(input);
+    });
+  }
+
   async function emulate(input,path,duration,capture_start) {
 
     var frameBuffer32 = new Uint32Array(1024 * 625);
@@ -89,10 +95,9 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
         // it doesn't have any line numbers.
         if (/[^\0-\x7e]/.test(input) || !/^ *[0-9]/m.test(input)) {
           /* Tokeniser input method */
-          var t         = await tokeniser.create();
           var tokenised;
           try {
-            tokenised = await t.tokenise(input);
+            tokenised = await tokenise(input);
           }
           catch (e) {
             console.log("Tokenisation FAILED");
@@ -203,7 +208,8 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
 
 
       return {
-        emulate:emulate
+        emulate:emulate,
+        tokenise:tokenise
       };
     }
   );

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,8 @@ git clone https://github.com/stardot/beebasm.git
 cd beebasm/src
 make all
 cd ../..
-echo 'PUTTEXT "text.bas", "!BOOT", 0' > beebasm/makedisk.asm
+echo 'PUTFILE "tokenised.bas", "TWEET", 0' > beebasm/makedisk2.asm
+echo 'PUTTEXT "run.txt", "!BOOT", 0' >> beebasm/makedisk2.asm
 
 echo Getting GXR ROM
 ln -s ./node_modules/jsbeeb/roms/ roms

--- a/mentions.js
+++ b/mentions.js
@@ -147,7 +147,7 @@ async function extendTruncated(timeline){
 		bas = bas.replace(/@\w+/g, "").trim(); // get rid of tags and white space
 		var basic = (bas.match(/^\d/) != null) || // code must start with digit
 		bas.includes("=") ||
-		(bas.match("[^\0-\x7e]")!=null); // Tokens and/or clamp emoji for compressed
+		(bas.match("[^\0-\x7e]")!=null); // Tokens and/or emoji.
 		return basic;
 	}
 

--- a/parser.js
+++ b/parser.js
@@ -23,9 +23,9 @@ return output;
 
 function isBASIC(bas){ // TODO convert to regex
   bas = bas.replace(/@\w+/g, "").trim(); // get rid of tags and white space
-  var basic = (bas.match(/^\d/) != null) || // code must start with digit
-  bas.includes("=") ||
-  (bas.match("[^\0-\x7e]")!=null); // Tokens and/or clamp emoji for compressed
+  var basic = (bas.match(/^\d/) != null) || // Line number.
+  bas.includes("=") || // Or contains an equals sign.
+  (bas.match("[^\0-\x7e]")!=null); // Or contains tokens.
   return basic;
 }
 
@@ -106,10 +106,8 @@ var one_hour = 2000000*60*60;
   }
   tweet.text = c.input;
   c.input = processInput(tweet, c.compressed);
-  // TODO really we need to be creating a fully tokenized BASIC program below 
-  if (c.emulator=="beebjit") {c.input = detokenize(c.input)}
   c.rude = (customFilter.clean(c.input) != c.input);
-  c.isBASIC = isBASIC(tweet.text);
+  c.isBASIC = c.compressed || c.emulator === 'beebjit' || isBASIC(tweet.text);
 
   console.log("\n",c);
   return c;

--- a/parser.js
+++ b/parser.js
@@ -8,19 +8,6 @@ const Filter       = require('bad-words');
 const customFilter = new Filter({ placeHolder: '*'});
 //customFilter.addWords('words','here');
 
-function detokenize(string){
-const tokens = ["AND ","DIV ","EOR ","MOD ","OR ","ERROR ","LINE ","OFF ","STEP ","SPC","TAB(","ELSE ","THEN ","line no. ","OPENIN","PTR","PAGE ","TIME ","LOMEM ","HIMEM ","ABS","ACS","ADVAL","ASC","ASN","ATN","BGET","COS","COUNT ","DEG","ERL ","ERR ","EVAL","EXP","EXT","FALSE ","FN","GET ","INKEY","INSTR","INT","LEN","LN","LOG","NOT ","OPENIN","OPENOUT","PI ","POINT(","POS ","RAD","RND","SGN","SIN","SQR","TAN","TO ","TRUE ","USR","VAL","VPOS ","CHR$","GET$ ","INKEY$","LEFT$(","MID$(","RIGHT$(","STR$","STRING$(","EOF ","AUTO ","DELETE ","LOAD ","LIST ","NEW ","OLD ","RENUMBER ","SAVE ","PUT","PTR","PAGE ","TIME ","LOMEM ","HIMEM ","SOUND ","BPUT","CALL ","CHAIN ","CLEAR ","CLOSE","CLG ","CLS ","DATA ","DEF ","DIM ","DRAW ","END ","ENDPROC ","ENVELOPE ","FOR ","GOSUB ","GOTO ","GCOL ","IF ","INPUT ","LET ","LOCAL ","MODE ","MOVE ","NEXT ","ON ","VDU ","PLOT ","PRINT ","PROC","READ ","REM ","REPEAT ","REPORT ","RESTORE ","RETURN ","RUN ","STOP ","COLOUR ","TRACE ","UNTIL ","WIDTH ","OSCLI"];
-
-var graphemes = splitter.splitGraphemes(string.trim());
-var output = "";
-
- for (let i = 0; i<graphemes.length; i++){
-	   var g = graphemes[i].codePointAt(0) & 0xff;
-           output += g>=0x80 ? " "+tokens[g-0x80] : graphemes[i];
- }
-return output;
-}
-
 function isBASIC(bas){ // TODO convert to regex
   bas = bas.replace(/@\w+/g, "").trim(); // get rid of tags and white space
   var basic = (bas.match(/^\d/) != null) || // Line number.

--- a/tweet.js
+++ b/tweet.js
@@ -15,6 +15,19 @@
 
   const twitter          = new Twitter(API_KEYS);
 
+  function detokenize(string){
+    const tokens = ["AND ","DIV ","EOR ","MOD ","OR ","ERROR ","LINE ","OFF ","STEP ","SPC","TAB(","ELSE ","THEN ","line no. ","OPENIN","PTR","PAGE ","TIME ","LOMEM ","HIMEM ","ABS","ACS","ADVAL","ASC","ASN","ATN","BGET","COS","COUNT ","DEG","ERL ","ERR ","EVAL","EXP","EXT","FALSE ","FN","GET ","INKEY","INSTR","INT","LEN","LN","LOG","NOT ","OPENIN","OPENOUT","PI ","POINT(","POS ","RAD","RND","SGN","SIN","SQR","TAN","TO ","TRUE ","USR","VAL","VPOS ","CHR$","GET$ ","INKEY$","LEFT$(","MID$(","RIGHT$(","STR$","STRING$(","EOF ","AUTO ","DELETE ","LOAD ","LIST ","NEW ","OLD ","RENUMBER ","SAVE ","PUT","PTR","PAGE ","TIME ","LOMEM ","HIMEM ","SOUND ","BPUT","CALL ","CHAIN ","CLEAR ","CLOSE","CLG ","CLS ","DATA ","DEF ","DIM ","DRAW ","END ","ENDPROC ","ENVELOPE ","FOR ","GOSUB ","GOTO ","GCOL ","IF ","INPUT ","LET ","LOCAL ","MODE ","MOVE ","NEXT ","ON ","VDU ","PLOT ","PRINT ","PROC","READ ","REM ","REPEAT ","REPORT ","RESTORE ","RETURN ","RUN ","STOP ","COLOUR ","TRACE ","UNTIL ","WIDTH ","OSCLI"];
+
+    var graphemes = splitter.splitGraphemes(string.trim());
+    var output = "";
+
+    for (let i = 0; i<graphemes.length; i++){
+      var g = graphemes[i].codePointAt(0) & 0xff;
+      output += g>=0x80 ? " "+tokens[g-0x80] : graphemes[i];
+    }
+    return output;
+  }
+
   function post (endpoint, params) {
     return new Promise((resolve, reject) => {
       twitter.post(endpoint, params, (error, data, response) => {
@@ -56,7 +69,7 @@
     console.log("Media post DONE ");
 
     // Post to discord too
-    var content = "["+text+"](https://www.twitter.com/"+response.in_reply_to_screen_name+">) posted \n```basic\n"+input+"```\n"+response.entities.media[0].media_url_https+"\n[See original tweet](https://www.twitter.com/bbcmicrobot/status/"+response.id_str+">)\n";
+    var content = "["+text+"](https://www.twitter.com/"+response.in_reply_to_screen_name+">) posted \n```basic\n"+detokenise(input)+"```\n"+response.entities.media[0].media_url_https+"\n[See original tweet](https://www.twitter.com/bbcmicrobot/status/"+response.id_str+">)\n";
     console.log(content);
 
     if (typeof discordClient === 'undefined') {


### PR DESCRIPTION
This uses jsbeeb's tokeniser for beebjit.  Some trickery is employed to make it appear that the program is just `RUN`, for more consistent output with when jsbeeb+tokeniser is used.  We could scrap this and just have the uncleared screen show e.g. `CHAIN"TWEET"`.

I've moved the detokenisation to just get done for what's reported to discord - it's still rather primitive (it should probably not expand tokens in strings for example) but it's probably more readable than the tokenised version so I guess it's still wanted there.