### PR TITLE
Make media filenames consistent between emulators

### DIFF
--- a/client.js
+++ b/client.js
@@ -236,7 +236,6 @@ var clientID = "Cli0";
         };
         // Set up twtr object to mock the 'tweet' methods that we use.
         twtr = {};
-        var hasAudio = (audio_file !== null);
         twtr.videoReply = function(filename,mediaType,replyTo,text,tweet,checksum,hasAudio) {
           console.log("Generated " + mediaType);
           exec("xdg-open "+filename);

--- a/client.js
+++ b/client.js
@@ -77,10 +77,11 @@ var clientID = "Cli0";
 
         var start   = new Date()
 
+        var media_path = "./tmp/"+tweet.id_str;
         // Emulate
         if (c.emulator == "beebjit") {
-          var path = "./tmp/beebjit_frame_";
-          var prefix = "";
+          var frame_path = "./tmp/beebjit_frame_";
+          var audio_file = null;
           var pixel_format = "bgra";
           var emu_name = "beebjit";
 
@@ -127,14 +128,15 @@ var clientID = "Cli0";
           console.log(beebjit_cmd);
         } else // JSbeeb
         {
-          var path = "./tmp/"+tweet.id_str;
-          var prefix = "frame";
+          var frame_path = media_path + "frame";
+          var audio_file = media_path + "audiotrack.raw";
           var pixel_format = "rgba";
           var emu_name = "jsbeeb";
-          var frames  = await emulator.emulate(c.input,path,emulationDuration,startFrame);
+          var frames  = await emulator.emulate(c.input,frame_path,audio_file,emulationDuration,startFrame);
+          if (!fs.existsSync(audio_file)) audio_file = null;
         }
 
-        // Tweet ID will be used in tmp filename passed into shell exec, so check it's safe.  For a real tweet it should be numeric while for a testcase it can contain alphanumerics.
+        // Tweet ID will be used in tmp filenames passed into shell exec, so check it's safe.  For a real tweet it should be numeric while for a testcase it can contain alphanumerics.
         if (/\W/.test(tweet.id_str)) {
           console.error("id_str contained unexpected character");
           process.exit();
@@ -146,41 +148,42 @@ var clientID = "Cli0";
         // Count unique video frames
 	var shasum_check = (await exec("sha1sum client.js  | awk '{print $1}' | wc -l")); // should equal 1
 	var shasum = (shasum_check > 0) ? "sha1sum" : "shasum";
-        var frames = (await exec(shasum+" "+path+prefix+"*."+pixel_format+" | awk '{print $1}' | wc -l"));
-        var uniqueFrames = (await exec(shasum+" "+path+prefix+"*."+pixel_format+" | awk '{print $1}' | sort | uniq | wc -l"));
+        var frames = (await exec(shasum+" "+frame_path+"*."+pixel_format+" | awk '{print $1}' | wc -l"));
+        var uniqueFrames = (await exec(shasum+" "+frame_path+"*."+pixel_format+" | awk '{print $1}' | sort | uniq | wc -l"));
 
-        console.log("Captured "+frames+" frames ("+uniqueFrames+" unique) "+path+prefix);
+        console.log("Captured "+frames+" frames ("+uniqueFrames+" unique) "+frame_path);
 
    	start = new Date();
-
-        var hasAudio = fs.existsSync(path+"audiotrack.raw");
 
         if (frames == 0) {
           // NO VIDEO -> NOTHING
           var ffmpegCmd = "";
-        } else if (uniqueFrames==1 && !hasAudio) {
+        } else if (uniqueFrames==1 && audio_file === null) {
           // STATIC IMAGE WITHOUT SOUND -> PNG SCREENSHOT
-          var mediaFilename = path+'.png';
+          var mediaFilename = media_path+'.png';
           var mediaType = 'image/png';
-          var ffmpegCmd = 'ffmpeg -hide_banner -y -f rawvideo -pixel_format '+pixel_format+' -video_size 640x512  -i '+path+prefix+(frames-1)+'.'+pixel_format+' -vf "scale=1280:1024" '+mediaFilename
+          var ffmpegCmd = 'ffmpeg -hide_banner -y -f rawvideo -pixel_format '+pixel_format+' -video_size 640x512  -i '+frame_path+(frames-1)+'.'+pixel_format+' -vf "scale=1280:1024" '+mediaFilename
         } else {
           // ANIMATION OR STATIC IMAGE WITH SOUND -> MP4 VIDEO
-          var mediaFilename = path+'.mp4';
+          var mediaFilename = media_path+'.mp4';
           var mediaType = 'video/mp4';
           var ffmpegCmd = 'ffmpeg -hide_banner -loglevel panic ';
-          if (hasAudio) {
-            ffmpegCmd = ffmpegCmd + '-f f32le -ar 44100 -ac 1 -i '+path+'audiotrack.raw ';
+          if (audio_file !== null) {
+            ffmpegCmd = ffmpegCmd + '-f f32le -ar 44100 -ac 1 -i '+audio_file;
           }
-          ffmpegCmd = ffmpegCmd + '-y -f image2 -r 50 -s 640x512 -pix_fmt '+pixel_format+' -vcodec rawvideo -i '+path+prefix+'%d.'+pixel_format+'  -af "highpass=f=50, lowpass=f=15000,volume=0.5" -filter:v "scale=1280:1024" -q 0 -b:v 8M -b:a 128k -c:v libx264 -pix_fmt yuv420p -strict -2 -shortest '+mediaFilename
+          ffmpegCmd = ffmpegCmd + '-y -f image2 -r 50 -s 640x512 -pix_fmt '+pixel_format+' -vcodec rawvideo -i '+frame_path+'%d.'+pixel_format+'  -af "highpass=f=50, lowpass=f=15000,volume=0.5" -filter:v "scale=1280:1024" -q 0 -b:v 8M -b:a 128k -c:v libx264 -pix_fmt yuv420p -strict -2 -shortest '+mediaFilename
         }
 
         if (frames > 0) {
           await exec(ffmpegCmd);
-          var checksum = await exec(shasum+" "+path+prefix+(frames-1)+'.'+pixel_format+" | awk '{print $1}'");
+          var checksum = await exec(shasum+" "+frame_path+(frames-1)+'.'+pixel_format+" | awk '{print $1}'");
         } else {
           var checksum = '';
         }
-        exec('rm -f '+path+'*.'+pixel_format+' '+path+'*.raw');
+        exec('rm -f '+frame_path+'*.'+pixel_format);
+        if (audio_file !== null) {
+          fs.unlinkSync(audio_file);
+        }
 
         var end = new Date() - start
         console.log("Ffmpeg DONE in %ds ",end/1000);
@@ -188,6 +191,7 @@ var clientID = "Cli0";
         if (frames == 0) {
           twtr.noOutput(tweet);
         } else {
+          var hasAudio = (audio_file !== null);
           twtr.videoReply(mediaFilename,mediaType,tweet.id_str,"@"+tweet.user.screen_name,tweet,checksum,hasAudio,c.input);
         }
 
@@ -232,6 +236,7 @@ var clientID = "Cli0";
         };
         // Set up twtr object to mock the 'tweet' methods that we use.
         twtr = {};
+        var hasAudio = (audio_file !== null);
         twtr.videoReply = function(filename,mediaType,replyTo,text,tweet,checksum,hasAudio) {
           console.log("Generated " + mediaType);
           exec("xdg-open "+filename);

--- a/emulator.js
+++ b/emulator.js
@@ -6,7 +6,7 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
 
   const fs = require('fs');
 
-  var video, path, processor, cycles;
+  var video, processor, cycles;
   var thisEmulator = null;
   var MaxCyclesPerIter = 100 * 1000;
   var hexword = utils.hexword;
@@ -26,7 +26,7 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
     });
   }
 
-  async function emulate(input,path,duration,capture_start) {
+  async function emulate(input,frame_path,audio_file,duration,capture_start) {
 
     var frameBuffer32 = new Uint32Array(1024 * 625);
     var soundBuffer = new Float32Array(44100 * duration).fill(0); 
@@ -45,7 +45,7 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
         soundPoint = soundPoint + 882;
 
         var mode = processor.readmem(screenMode);
-        var fd = fs.openSync(path+'frame'+(frame-capture_start)+'.rgba', 'w');
+        var fd = fs.openSync(frame_path+(frame-capture_start)+'.rgba', 'w');
         // frameBuffer32 includes the frame border.  The area where the image is
         // varies a little by screen mode - it's always 640 pixels wide (i.e. 2560
         // bytes since each pixel is 4 bytes) but in mode 7 it is offset to the
@@ -138,7 +138,7 @@ function (Cpu6502, Video, SoundChip, models, DdNoise, Cmos,  utils,fdc,tokeniser
 
         // Check if the soundBuffer has any non-zero values.
         if (soundBuffer.some(function(elt, idx, a) { return elt != 0; })) {
-          await fs.writeFileSync( path+'audiotrack.raw', soundBuffer.slice(0, soundPoint),(err) => {
+          await fs.writeFileSync(audio_file, soundBuffer.slice(0, soundPoint),(err) => {
             if (err) throw err;
           });
         }


### PR DESCRIPTION
Always name the media filename based on tweet.id_str, like we already
did with jsbeeb.