### PR TITLE
feat: replace profanity filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1265.0",
-        "bad-words": "^3.0.3",
         "console-stamp": "^0.2.9",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
@@ -20,6 +19,7 @@
         "htmlparser2": "^8.0.1",
         "jsbeeb": "git+https://github.com/mattgodbolt/jsbeeb.git#8935c9a3a095e846f63c0e4a08070f76ad01473e",
         "mastodon": "^1.2.2",
+        "no-profanity": "^1.4.2",
         "npmlog": "^7.0.1",
         "request": "^2.88.2",
         "requirejs": "^2.3.6"
@@ -335,22 +335,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
-    "node_modules/bad-words": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
-      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
-      "dependencies": {
-        "badwords-list": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/badwords-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
-      "integrity": "sha512-oWhaSG67e+HQj3OGHQt2ucP+vAPm1wTbdp2aDHeuh4xlGXBdWwzZ//pfu6swf5gZ8iX0b7JgmSo8BhgybbqszA=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2810,6 +2794,14 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node_modules/no-profanity": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/no-profanity/-/no-profanity-1.4.2.tgz",
+      "integrity": "sha512-mg9E7w0LitTCz6J3T65nZnSzPKN9qc1VHWW0Yn6HUkU/VDWdgLBWoB/fWd3tJcfAk9fuzxAFysYbqACLE0lRjg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
@@ -4510,19 +4502,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
-    "bad-words": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
-      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
-      "requires": {
-        "badwords-list": "^1.0.0"
-      }
-    },
-    "badwords-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
-      "integrity": "sha512-oWhaSG67e+HQj3OGHQt2ucP+vAPm1wTbdp2aDHeuh4xlGXBdWwzZ//pfu6swf5gZ8iX0b7JgmSo8BhgybbqszA=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -6372,6 +6351,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "no-profanity": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/no-profanity/-/no-profanity-1.4.2.tgz",
+      "integrity": "sha512-mg9E7w0LitTCz6J3T65nZnSzPKN9qc1VHWW0Yn6HUkU/VDWdgLBWoB/fWd3tJcfAk9fuzxAFysYbqACLE0lRjg=="
     },
     "normalize-package-data": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "aws-sdk": "^2.1265.0",
-    "bad-words": "^3.0.3",
     "console-stamp": "^0.2.9",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
@@ -21,6 +20,7 @@
     "htmlparser2": "^8.0.1",
     "jsbeeb": "git+https://github.com/mattgodbolt/jsbeeb.git#8935c9a3a095e846f63c0e4a08070f76ad01473e",
     "mastodon": "^1.2.2",
+    "no-profanity": "^1.4.2",
     "npmlog": "^7.0.1",
     "request": "^2.88.2",
     "requirejs": "^2.3.6"

--- a/parser.js
+++ b/parser.js
@@ -3,10 +3,8 @@
 const TRY = (process.argv.indexOf("try") > -1)
 
 require('dotenv').config();
-const Filter       = require('bad-words');
-const customFilter = new Filter({ placeHolder: '*'});
-//customFilter.addWords('words','here');
 const Grapheme     = require('grapheme-splitter');
+const { isProfane } = require("no-profanity");
 var splitter = new Grapheme();
 const htmlparser2  = require('htmlparser2');
 
@@ -84,7 +82,7 @@ function parseTweet(toot){
   }
   toot.text = c.input;
   c.input = processInput(toot);
-  c.rude = (customFilter.clean(c.input) != c.input);
+    c.rude = isProfane(c.input);
 
   console.log("\n",c);
   return c;


### PR DESCRIPTION
Hi there!

I noticed your repository uses the `bad-words` package. I've recently released a new package called `no-profanity` which is backwards compatible with `bad-words` but contains more known profanities, and is about 150 times as fast with checking profanities.

This PR should fix that! 

Let me know if you have any questions